### PR TITLE
Fixed Patch inheritance to make restfulie work also with ruby 1.9.3

### DIFF
--- a/lib/restfulie/client/ext/http_ext.rb
+++ b/lib/restfulie/client/ext/http_ext.rb
@@ -14,8 +14,10 @@ module Net
       res
     end
 
-    class Patch < Get
-      METHOD = "PATCH"
+    if not HTTP.const_defined?(:Patch)
+      class Patch < Get
+        METHOD = "PATCH"
+      end
     end
   end
 end

--- a/lib/restfulie/client/ext/http_ext.rb
+++ b/lib/restfulie/client/ext/http_ext.rb
@@ -1,22 +1,26 @@
 module Net
   class HTTP
-    # Definition of a patch method in the same way that post works
-    def patch(path, data, initheader = nil, dest = nil, &block) # :yield: +body_segment+
-      res = nil
-      request(Patch.new(path, initheader), data) {|r|
-        r.read_body dest, &block
-        res = r
-      }
-      unless @newimpl
-        res.value
-        return res, res.body
+    if not method_defined? :patch
+      # Definition of a patch method in the same way that post works
+      def patch(path, data, initheader = nil, dest = nil, &block) # :yield: +body_segment+
+        res = nil
+        request(Patch.new(path, initheader), data) {|r|
+          r.read_body dest, &block
+          res = r
+        }
+        unless @newimpl
+          res.value
+          return res, res.body
+        end
+        res
       end
-      res
     end
 
-    if not HTTP.const_defined?(:Patch)
-      class Patch < Get
-        METHOD = "PATCH"
+    if not const_defined? :Patch
+      class Patch < HTTPRequest
+        METHOD = 'PATCH'
+        REQUEST_HAS_BODY = true
+        RESPONSE_HAS_BODY = true
       end
     end
   end


### PR DESCRIPTION
It looks like the Patch class inheritance was not defined correctly.
With this fix, the restfulie gem should now work with ruby 1.8, 1.9.1, 1.9.2 and 1.9.3.
