### PR TITLE
method 'with' should set headers properly

### DIFF
--- a/lib/restfulie/client/feature/base.rb
+++ b/lib/restfulie/client/feature/base.rb
@@ -31,7 +31,7 @@ module Restfulie::Client::Feature
     # * <tt>headers (e.g. {'Cache-control' => 'no-cache'})</tt>
     #
     def with(headers)
-      headers.merge!(headers)
+      self.headers.merge!(headers)
       self
     end
 

--- a/spec/unit/client/base_spec.rb
+++ b/spec/unit/client/base_spec.rb
@@ -6,4 +6,9 @@ describe Restfulie do
     Restfulie.at('http://guilhermesilveira.wordpress.com/').should_not == (Restfulie.at('http://guilhermesilveira.wordpress.com/'))
   end
 
+  it "should set headers when with options is given" do
+    response = Restfulie.at('http://google.com').with({'Service-Ticket' => 'foobar'})
+    response.headers.should == {'Service-Ticket' => 'foobar'}
+  end
+
 end


### PR DESCRIPTION
once you try Restifulie.at(some_url).with(some_headers), the headers options (some_headers in this case) wasn't being merged.

'with' method was merging headers (local variable) with itself and returning self (a restfulie object).
